### PR TITLE
refactor Created folder main and added package declaration #35

### DIFF
--- a/src/main/CMV.java
+++ b/src/main/CMV.java
@@ -1,3 +1,5 @@
+package main;
+
 public class CMV {
     
     private boolean[] cmv_vector = new boolean[15];

--- a/src/main/Main.java
+++ b/src/main/Main.java
@@ -1,3 +1,5 @@
+package main;
+
 public class Main {
     public static void main(String[] args) {
         System.out.println("Hello, world!");

--- a/src/main/Parameters.java
+++ b/src/main/Parameters.java
@@ -1,3 +1,5 @@
+package main;
+
 public class Parameters {
     public static double LENGTH1;
     public static double RADIUS1;


### PR DESCRIPTION
This fixes the issue where objects could not be accessed from other classes, such as junit files. All files in `main` folder has to have `package main;` at the top and for files in `junit` folder has to have `package junit;`.