### PR TITLE
feat: added a getter function to the cmv, closes #54

### DIFF
--- a/src/junit/LIC_test.java
+++ b/src/junit/LIC_test.java
@@ -8,6 +8,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class LIC_test {
+
+    @Test 
+    public void cmv_getter_test(){
+        //pretty useless test, works cause lic5-calculate is run in the constructor
+        int[][] datapoints = {{4,0},{3,0},{2,0},{1,0},{0,0}};
+        CMV cmv = new CMV(datapoints);
+        assertTrue(cmv.get_cmv_value(5));
+    }
     //LIC 5
     @Test
     public void checkIfValidGivesTrue(){

--- a/src/main/CMV.java
+++ b/src/main/CMV.java
@@ -31,7 +31,9 @@ public class CMV {
         cmv_vector[14] = lic14_calculate();
     }
 
-
+    public boolean get_cmv_value(int lic_number){
+        return cmv_vector[lic_number];
+    }
 
     private boolean lic0_calculate() {
         for (int j = 1; j < this.datapoints.length; j++){ 


### PR DESCRIPTION
Added a getter function to the CMV class, enables us to test the lic-calculate functions by just accessing the cmv_vector without having to make the lic-calculate functions public