### PR TITLE
fix: Implemented tests for PUM and fixes for PUM #23

### DIFF
--- a/src/junit/PUM_Test.java
+++ b/src/junit/PUM_Test.java
@@ -1,0 +1,127 @@
+package junit;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import main.PUM;
+
+public class PUM_Test {
+
+    /**
+     *  Checks the #1 entry on page 7 from decide.pdf
+     * 
+     *  PUM[0, 1] should be false because LCM[0, 1] is ANDD, and at least one
+     *  of CMV[0] and CMV[1] is false.
+     * 
+     *  Expected: PUM[0][1] = false
+     */
+    @Test
+    public void test_pum_entry1() {
+
+        // LCM[0, 1] is ANDD
+        int[][] lcm = new int[15][15];
+        lcm[0][1] = 1;
+
+        // Now, CMV[0] = true, and CMV[1] = false
+        boolean[] cmv = new boolean[15];
+        cmv[0] = true;
+
+        PUM pum = new PUM(lcm, cmv);
+        boolean[][] pum_mat = pum.calculate_pum();
+        assertEquals(false, pum_mat[0][1]);
+
+        // Now, CMV[0] = false, and CMV[1] = true
+        cmv = new boolean[15];
+        cmv[1] = true;
+
+        pum = new PUM(lcm, cmv);
+        pum_mat = pum.calculate_pum();
+        assertEquals(false, pum_mat[0][1]);
+    }
+
+    /**
+     *  Checks the #2 entry on page 7 from decide.pdf
+     * 
+     *  PUM[0, 2] should be true because LCM[0, 2] is ORR, and at least one
+     *  of CMV[0] and CMV[2] is true.
+     * 
+     *  Expected: PUM[0][2] = true
+     */
+    @Test
+    public void test_pum_entry2() {
+
+        // LCM[0, 2] is ORR
+        int[][] lcm = new int[15][15];
+        lcm[0][2] = 0;
+
+        // Now, CMV[0] = true, and CMV[2] = false
+        boolean[] cmv = new boolean[15];
+        cmv[0] = true;
+
+        PUM pum = new PUM(lcm, cmv);
+        boolean[][] pum_mat = pum.calculate_pum();
+        assertEquals(true, pum_mat[0][2]);
+
+        // Now, CMV[0] = false, and CMV[2] = true
+        cmv = new boolean[15];
+        cmv[2] = true;
+
+        pum = new PUM(lcm, cmv);
+        pum_mat = pum.calculate_pum();
+        assertEquals(true, pum_mat[0][2]);
+    }
+
+    /**
+     *  Checks the #3 entry on page 7 from decide.pdf
+     * 
+     *  PUM[1, 2] should be true because LCM[1, 2] is ORR, and at least one
+     *  of CMV[1] and CMV[2] is true.
+     * 
+     *  Expected: PUM[1][2] = true
+     */
+    @Test
+    public void test_pum_entry3() {
+
+        // LCM[0, 2] is ORR
+        int[][] lcm = new int[15][15];
+        lcm[1][2] = 0;
+
+        // Now, CMV[0] = true, and CMV[2] = false
+        boolean[] cmv = new boolean[15];
+        cmv[1] = true;
+
+        PUM pum = new PUM(lcm, cmv);
+        boolean[][] pum_mat = pum.calculate_pum();
+        assertEquals(true, pum_mat[1][2]);
+
+        // Now, CMV[0] = false, and CMV[2] = true
+        cmv = new boolean[15];
+        cmv[2] = true;
+
+        pum = new PUM(lcm, cmv);
+        pum_mat = pum.calculate_pum();
+        assertEquals(true, pum_mat[1][2]);
+    }
+
+    /**
+     *  Checks the #5 entry on page 7 from decide.pdf
+     * 
+     *  PUM[0, 4] should be true because LCM[0, 4] is NOTUSED
+     * 
+     *  Expected: PUM[0][4] = true
+     */
+    @Test
+    public void test_pum_entry5() {
+
+        // LCM[0, 2] is NOTUSED
+        int[][] lcm = new int[15][15];
+        lcm[0][4] = -1;
+
+        boolean[] cmv = new boolean[15];
+
+        PUM pum = new PUM(lcm, cmv);
+        boolean[][] pum_mat = pum.calculate_pum();
+        assertEquals(true, pum_mat[0][4]);
+    }
+}

--- a/src/main/PUM.java
+++ b/src/main/PUM.java
@@ -1,24 +1,12 @@
-
-// PUM function
-// The Conditions Met Vector (CMV) can now be used in conjunction with the Logical Connector Matrix (LCM) to form the Preliminary Unlocking Matrix (PUM). The entries in the LCM represent the logical connectors to be used between pairs of LICs to determine the corresponding entry in the PUM.
-
-// CONDITIONS
-// LCM[i,j] represents the boolean operator to be applied to CMV[i] and CMV[j].
-// PUM[i,j] is set according to the result of this operation
-// eg: LCM[i, j] with CMV[i, j] as a state check = PUM[i, j]?
-
-
-// (Note that the LCM is symmetric, i.e. LCM[i,j]=LCM[j,i] for all i and j.)
-
 package main;
+
 public class PUM {
     
     private int[][] lcm_datapoints;
-    private int[] cmv_vector;
-    private int[][] pum_matrix;
+    private boolean[] cmv_vector;
+    private boolean[][] pum_matrix;
 
-
-    public PUM(int[][] lcm_datapoints, int[] cmv_vector){
+    public PUM(int[][] lcm_datapoints, boolean[] cmv_vector){
         // get LCM vector
         this.lcm_datapoints = lcm_datapoints;
 
@@ -26,18 +14,14 @@ public class PUM {
         this.cmv_vector = cmv_vector;
     }
 
-    public int[][] calculate_pum(){
-
-    // If LCM[i,j] is NOTUSED, then PUM[i,j] should be set to true.
-    // If LCM[i,j] is ANDD, PUM[i,j] should be set to true 
-    // only if (CMV[i] AND CMV[j]) is true.
-    
-        pum_matrix = new int[15][15];
-        for (int i = 0; i < lcm_datapoints.length; i++){
-            for (int j = 0; j < lcm_datapoints[j].length; j++){
-                if (lcm_datapoints[i][j] == -1 || (lcm_datapoints[i][j] == 1 && cmv_vector[i] == 1 && cmv_vector[j] == 1)){
-                    pum_matrix[i][j] = 1;
-                    // System.out.println("in if");
+    public boolean[][] calculate_pum() {
+        pum_matrix = new boolean[15][15];
+        for (int i = 0; i < lcm_datapoints.length; i++) {
+            for (int j = 0; j < lcm_datapoints[i].length; j++) {
+                if  (lcm_datapoints[i][j] == -1 ||
+                    (lcm_datapoints[i][j] == 1 && cmv_vector[i] && cmv_vector[j]) ||
+                    (lcm_datapoints[i][j] == 0 && (cmv_vector[i] || cmv_vector[j]))) {
+                    pum_matrix[i][j] = true;
                 }
             }
         }


### PR DESCRIPTION
- The condition where ORR is used was missing
- Changed `pum_matrix` to arr of boolean
- `calculate_pum` now returns a boolean matrix