### PR TITLE
Fix bug in tests involving LIC11 #82

### DIFF
--- a/src/junit/LIC_test.java
+++ b/src/junit/LIC_test.java
@@ -108,6 +108,7 @@ public class LIC_test {
     @Test
     public void checkIfValidGivesTrueLic11(){
         int[][] datapoints = {{3,0},{0,0},{0,0},{0,0},{2,0}};
+        Parameters.G_PTS = 3;
         CMV cmv = new CMV(datapoints);
         assertTrue(cmv.get_cmv_value(11));
     }
@@ -120,6 +121,7 @@ public class LIC_test {
     @Test
     public void checkIfInvalidGivesFalseLic11(){
         int[][] datapoints = {{3,0},{0,0},{0,0},{0,0},{4,0}};
+        Parameters.G_PTS = 3;
         CMV cmv = new CMV(datapoints);
         assertFalse(cmv.get_cmv_value(11));
     }


### PR DESCRIPTION
The value of G_PTS of the Parameters class was uninitialised when running the test resulting in wrong value returning.
closes #82 